### PR TITLE
Fix PHP memory leak

### DIFF
--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -54,14 +54,25 @@ RUN apk add --no-cache --update --virtual build-deps \
   && apk del --no-cache build-deps
 
 # NewRelic setup.
+ENV NEWRELIC_VERSION="8.7.0.242"
 RUN mkdir -p /opt && cd /opt \
-  && export NEWRELIC_VERSION=$(curl -sS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p') \
-  && wget "http://download.newrelic.com/php_agent/release/${NEWRELIC_VERSION}.tar.gz" \
-  && gzip -dc ${NEWRELIC_VERSION}.tar.gz | tar xf - \
-  && cd "${NEWRELIC_VERSION}" \
+  && export NEWRELIC_RELEASE="newrelic-php5-${NEWRELIC_VERSION}-linux-musl" \
+  && wget "http://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/${NEWRELIC_RELEASE}.tar.gz" \
+  && gzip -dc ${NEWRELIC_RELEASE}.tar.gz | tar xf - \
+  && cd "${NEWRELIC_RELEASE}" \
   && NR_INSTALL_SILENT=true NR_INSTALL_USE_CP_NOT_LN=true ./newrelic-install install \
   && cd .. \
-  && rm -rf "${NEWRELIC_VERSION}"*
+  && rm -rf "${NEWRELIC_RELEASE}"*
+
+# Disabled till NewRelic fix the memory leak in agent version 9.
+# RUN mkdir -p /opt && cd /opt \
+#   && export NEWRELIC_VERSION=$(curl -sS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p') \
+#   && wget "http://download.newrelic.com/php_agent/release/${NEWRELIC_VERSION}.tar.gz" \
+#   && gzip -dc ${NEWRELIC_VERSION}.tar.gz | tar xf - \
+#   && cd "${NEWRELIC_VERSION}" \
+#   && NR_INSTALL_SILENT=true NR_INSTALL_USE_CP_NOT_LN=true ./newrelic-install install \
+#   && cd .. \
+#   && rm -rf "${NEWRELIC_VERSION}"*
 
 # Disabled by default.
 ENV NEWRELIC_ENABLED=0

--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -53,6 +53,13 @@ RUN apk add --no-cache --update --virtual build-deps \
   && rm -rf /tmp/pear \
   && apk del --no-cache build-deps
 
+# Install drush.
+RUN curl -s -L https://github.com/drush-ops/drush/releases | egrep -o '/drush-ops/drush/releases/download/[v.0-8]*/drush.phar' | head -n1 | wget --base=http://github.com/ -i - -O /usr/local/bin/drush
+RUN chmod +x /usr/local/bin/drush
+
+# Install composer.
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && mkdir /.composer
+
 # NewRelic setup.
 ENV NEWRELIC_VERSION="8.7.0.242"
 RUN mkdir -p /opt && cd /opt \


### PR DESCRIPTION
The leak is caused by version 9.x of the NewRelic agent, see my forum post for more info: https://discuss.newrelic.com/t/php-agent-9-serious-memory-leak-issues/80863/12

This PR also moves the composer/drush installs from our app containers to here which should hopefully speed builds up.