### PR TITLE
Add `tzdata` to awscli container.

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,7 +1,7 @@
 ARG ALPINE_VERSION=3.9
 FROM alpine:${ALPINE_VERSION}
 
-ARG AWSCLI_VERSION=1.16.116
+ARG AWSCLI_VERSION=1.18.45
 
 RUN apk add --update --no-cache \
     bash \
@@ -9,8 +9,9 @@ RUN apk add --update --no-cache \
     python3 \
     jq \
     pv \
-    mysql-client=10.3.17-r0 \
-    postgresql-client=11.5-r0 \
+    tzdata \
+    mysql-client=10.3.22-r0 \
+    postgresql-client=11.7-r0 \
   && pip3 install --upgrade awscli==${AWSCLI_VERSION} boto3 \
   && rm -f /tmp/* /etc/apk/cache/*
 


### PR DESCRIPTION
This resolves an issue where we need to create database restores
relative to local time, and date conversion from UTC won't work without
`tzdata`.

This also upgrade the following packages to their latest stable:
* mysql-client: 10.3.17 -> 10.3.22
* postgresql-client: 11.5 -> 11.7
* awscli 1.16.116 -> 1.18.45