### PR TITLE
Upgrade PHP NewRelic integration from 9.7.x to 9.11.x.

### DIFF
--- a/newrelic-php-daemon/Dockerfile
+++ b/newrelic-php-daemon/Dockerfile
@@ -1,10 +1,10 @@
-ARG ALPINE_VERSION=3.9
+ARG ALPINE_VERSION=3.11
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --update --no-cache bash socat curl \
+RUN apk add --update --no-cache bash curl \
   && rm -f /tmp/* /etc/apk/cache/*
 
-ENV NEWRELIC_VERSION="9.7.0.258"
+ENV NEWRELIC_VERSION="9.11.0.267"
 RUN mkdir -p /opt && cd /opt \
   && export NEWRELIC_RELEASE="newrelic-php5-${NEWRELIC_VERSION}-linux-musl" \
   && wget "http://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/${NEWRELIC_RELEASE}.tar.gz" \
@@ -15,14 +15,12 @@ RUN mkdir -p /opt && cd /opt \
 COPY ./conf/newrelic.cfg /etc/newrelic/
 COPY ./conf/run.sh /newrelic-run
 
-# The port that the NewRelic daemon launches on, this is configured in
-# conf/newrelic.cfg too.
-ENV NEWRELIC_AGENT_PORT=3018
-# The port that we expose the daemon port on, this is what other containers
-# should connect to.
-ENV NEWRELIC_CONTAINER_PORT=3019
+# The address & port that the NewRelic daemon will bind to.
+ENV NEWRELIC_DAEMON_ADDRESS="0.0.0.0:3019"
 
 ENV IS_KUBERNETES=0
 
+# This should match the port above.
 EXPOSE 3019
+
 CMD ["/newrelic-run"]

--- a/newrelic-php-daemon/conf/newrelic.cfg
+++ b/newrelic-php-daemon/conf/newrelic.cfg
@@ -96,7 +96,8 @@ loglevel=info
 #          started by the super-user. This is a fundamental OS limitation
 #          and not one imposed by the daemon itself.
 # Default: "/tmp/.newrelic.sock"
-port=3018
+# This is overridden by the '--address' flag in the entrypoint script.
+#port=3019
 
 # Setting: ssl
 # Type   : boolean

--- a/newrelic-php-daemon/conf/run.sh
+++ b/newrelic-php-daemon/conf/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
-# Inspired by https://github.com/hipages/docker-newrelic-php-daemon/blob/master/build/docker-entrypoint
-socat TCP-LISTEN:${NEWRELIC_CONTAINER_PORT},reuseaddr,fork,su=nobody TCP:127.0.0.1:${NEWRELIC_AGENT_PORT} &
-
-exec /usr/bin/newrelic-daemon -c /etc/newrelic/newrelic.cfg -f
+exec /usr/bin/newrelic-daemon -c /etc/newrelic/newrelic.cfg \
+  --address="${NEWRELIC_DAEMON_ADDRESS}" \
+  --watchdog-foreground

--- a/php/base/Dockerfile
+++ b/php/base/Dockerfile
@@ -82,7 +82,7 @@ ARG PHP_TYPE
 RUN /usr/local/bin/install-fpm-healthcheck ${PHP_TYPE} ${FPM_HEALTHCHECK_VERSION}
 
 # NewRelic setup.
-ENV NEWRELIC_VERSION="9.7.0.258"
+ENV NEWRELIC_VERSION="9.11.0.267"
 RUN mkdir -p /opt && cd /opt \
   && export NEWRELIC_RELEASE="newrelic-php5-${NEWRELIC_VERSION}-linux-musl" \
   && wget "http://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/${NEWRELIC_RELEASE}.tar.gz" \

--- a/php/dev/Dockerfile
+++ b/php/dev/Dockerfile
@@ -6,7 +6,7 @@ FROM lendingworks/php:${PHP_VERSION}-${PHP_TYPE}
 # Increment this to trigger a full rebuild.
 ENV CONTAINER_VERSION '1.0.0'
 
-ARG XDEBUG_VERSION=2.6.0
+ARG XDEBUG_VERSION=2.9.6
 
 RUN apk add --no-cache --update --virtual build-deps ${PHPIZE_DEPS} \
   && pecl install xdebug-${XDEBUG_VERSION} \


### PR DESCRIPTION
Also in this change:
* Upgrade the `newrelic-php-daemon` container's base Alpine version from 3.9 to 3.11
* Remove the `socat` bind hack from the daemon container now that it supports non-localhost bindings
* Switch to running the daemon watchdog, rather than the daemon itself, in the foreground for better stability
* Upgrade Xdebug in `php-dev` from 2.6.0 to 2.9.6

As part of this change, the container tag will be bumped to `v2`, i.e. `lendingworks/newrelic-php-daemon:v2`.