### PR TITLE
Github Org Backup: Fix undefined key error

### DIFF
--- a/github-org-backup/src/index.ts
+++ b/github-org-backup/src/index.ts
@@ -581,7 +581,7 @@ class GithubOrgBackup {
             `${backupLogPrefix} Removing backup, retention period has been breached`
           );
           await deleteObject({
-            Key: dailyBackups[timestamp].key,
+            Key: cleanupType.backups[timestamp].key,
           });
           deletionCount++;
         }


### PR DESCRIPTION
This fixes an issue cleaning up monthly backups - instead of a dynamic backups property, the daily backups list was being used for monthly backups as well.